### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://kvmody.visualstudio.com/5c2d4581-6bd2-44d2-96d8-d5718e2c20fc/9776f5e1-f26a-4f4d-9728-71c59fbdda98/_apis/work/boardbadge/3d57446e-190e-4014-afde-b3e2cea13529)](https://kvmody.visualstudio.com/5c2d4581-6bd2-44d2-96d8-d5718e2c20fc/_boards/board/t/9776f5e1-f26a-4f4d-9728-71c59fbdda98/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://kvmody.visualstudio.com/5c2d4581-6bd2-44d2-96d8-d5718e2c20fc/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.